### PR TITLE
OpenCVの非互換のためバージョン固定

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-opencv-contrib-python
-opencv-python
+opencv-contrib-python==4.2.0.34
+opencv-python==4.2.0.34


### PR DESCRIPTION
OpenCV 4.3だと image_hash に非互換があるので4.2に固定