### PR TITLE
サーヴァント認識の閾値変更

### DIFF
--- a/fgogachacnt.py
+++ b/fgogachacnt.py
@@ -897,7 +897,7 @@ class Item:
         # 既存のアイテムとの距離を比較
         for i in dist_servant.keys():
             d = hasher.compare(hash_item, dist_servant[i])
-            if d <= 17: # 16だと誤認識
+            if d <= 20: # 16だと誤認識
                 itemfiles[i] = d
         if len(itemfiles) > 0:
             itemfiles = sorted(itemfiles.items(), key=lambda x:x[1])


### PR DESCRIPTION
アンリマユの距離が19のため元の17では認識されないので閾値を20に変更